### PR TITLE
Fix vercel.json: set framework and build to null for static site

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
-  "buildCommand": "",
-  "outputDirectory": "."
+  "framework": null,
+  "buildCommand": null,
+  "outputDirectory": null
 }


### PR DESCRIPTION
Vercel was returning 404 because it was still trying to detect a framework. Setting all values to null forces static file serving.